### PR TITLE
updated version number to 0.0.7 to match npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/magicbookproject/magicbook-katex.git",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "name": "magicbook-katex",
   "description": "Katex plugin for magicbook",
   "author": "magicbookproject",


### PR DESCRIPTION
Bumps package version number to match npm version. 
* Currently repo shows v0.0.5. Npm version is v0.0.6

see:

<img width="1216" alt="Screen Shot 2019-06-24 at 10 10 01" src="https://user-images.githubusercontent.com/3622055/60025887-914cb780-9668-11e9-9c5a-ecec9fcc6b21.png">
