### PR TITLE
Fix inline math display issue

### DIFF
--- a/src/katex.js
+++ b/src/katex.js
@@ -18,7 +18,7 @@ Plugin.prototype = {
     extras.md.use(markdownitKatex);
 
     // Stylesheets
-    var css = path.join(__dirname, "..", "assets", "katex", "katex.scss");
+    var css = path.join(__dirname, "..", "node_modules/katex/dist", "katex.css");
     config.stylesheets = config.stylesheets || {};
     config.stylesheets.files = config.stylesheets.files || [];
     if(_.isString(config.stylesheets.files)) {
@@ -27,7 +27,7 @@ Plugin.prototype = {
     config.stylesheets.files.unshift(css);
 
     // Fonts
-    var fonts = path.join(__dirname, "..", "assets", "katex", "fonts", "**/*.*");
+    var fonts = path.join(__dirname, "node_modules/katex/dist", "fonts", "**/*.*");
     config.fonts = config.fonts || {};
     config.fonts.files = config.fonts.files || [];
     if(_.isString(config.fonts.files)) {


### PR DESCRIPTION
## Problem

Currently, the inline math is not rendering properly with the stylesheets from the `assets/` folder. Here's an example of the broken display:

<img width="229" alt="image" src="https://user-images.githubusercontent.com/6762203/227284126-057f2602-f4db-4363-858f-05c2c79c3588.png">

## Proposed Solution

Can we switch to using the package directly installed from NPM? This should resolve the issue and properly display inline math elements.
