### PR TITLE
Get path from `require.resolve()`

### DIFF
--- a/src/katex.js
+++ b/src/katex.js
@@ -17,8 +17,10 @@ Plugin.prototype = {
     // make sure we parse $-$ and $$-$$ into katex markup
     extras.md.use(markdownitKatex);
 
+    var katexPath = path.dirname(require.resolve("katex"));
+
     // Stylesheets
-    var css = path.join(__dirname, "../node_modules/katex/dist/katex.css");
+    var css = path.join(katexPath, "katex.css");
     config.stylesheets = config.stylesheets || {};
     config.stylesheets.files = config.stylesheets.files || [];
     if(_.isString(config.stylesheets.files)) {
@@ -27,7 +29,7 @@ Plugin.prototype = {
     config.stylesheets.files.unshift(css);
 
     // Fonts
-    var fonts = path.join(__dirname, "../node_modules/katex/dist/fonts/*.*");
+    var fonts = path.join(katexPath, "fonts/*.*");
     config.fonts = config.fonts || {};
     config.fonts.files = config.fonts.files || [];
     if(_.isString(config.fonts.files)) {


### PR DESCRIPTION
## Problem
The path for `katex`'s styles and fonts was hard-coded and won't work when the parent package has a compatible `katex` dependency.

## Fix
I have changed it to get the path from `require.resolve()` to correct the issue.