### PR TITLE
Transform back the character references

### DIFF
--- a/src/katex.js
+++ b/src/katex.js
@@ -50,6 +50,9 @@ Plugin.prototype = {
       file.$el('span[data-type="equation"],div[data-type="equation"]').each(function(i, el) {
         var jel = file.$el(this);
         var latex = jel.html();
+
+        latex = latex.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+
         var newEl = file.$el(katex.renderToString(latex, { displayMode: el.tagName == 'div' }));
         jel.replaceWith(newEl);
         found = true;


### PR DESCRIPTION
Some equations that contain '<', '>', '&' cause error during build because they get transformed to their reference (e.g. '&gt;') by cheerio. Replacing them back should fix it.